### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo ::set-output name=VERSION::$(node -e "console.log(require('./package.json').version)")
 
       - name: Publish
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           DOCKER_BUILDKIT: 1
           APP_BASE_PATH: "/billing"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore